### PR TITLE
Second argument is required for Context.String(). Closed code block.

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -21,7 +21,7 @@ func stat(c echo.Context) error {
 }
 
 func counter(c echo.Context) error {
-	return c.String(http.StatusOK)
+	return c.String(http.StatusOK, "counter")
 }
 
 func main() {
@@ -76,5 +76,5 @@ func main() {
 	e.GET("/counter.js", handlers.Counter)
 	e.Start(":8080")
 }
-
+```
 **Код находится в `src/routing`.**


### PR DESCRIPTION
1. Не компилируется без второго аргумента:
"not enough arguments in call to c.String
	have (number)
	want (int, string)"
2. Незакрытый блок с кодом, из-за этого не работает подсветка:
https://pahanini.gitbooks.io/golang-for-php-developers/content/routing.html